### PR TITLE
Update communities for Göteborg Sweden

### DIFF
--- a/communities/groups/groups.json
+++ b/communities/groups/groups.json
@@ -8742,21 +8742,12 @@
   },
   {
     "id": "fRQBrxp",
-    "name": "Slacklife Göteborg",
+    "name": "Slackline Göteborg",
     "lat": 57.7099488,
     "lng": 11.97020233,
     "createdDateTime": "2020-05-09",
-    "updatedDateTime": "2020-05-09",
+    "updatedDateTime": "2023-08-07",
     "facebook": "https://www.facebook.com/groups/215519055284206/"
-  },
-  {
-    "id": "R3cOn4I",
-    "name": "Slackline Göteborg",
-    "lat": 57.73729,
-    "lng": 11.97136,
-    "createdDateTime": "2020-05-09",
-    "updatedDateTime": "2020-05-09",
-    "facebook": "https://www.facebook.com/groups/5695569041/"
   },
   {
     "id": "lZheJ4W",


### PR DESCRIPTION
This commit:
- Removes dead group Slackline Göteborg.
- Renames active group to Slackline Göteborg. [Was renamed here](https://www.facebook.com/groups/215519055284206/permalink/2568947683274653/).